### PR TITLE
Upgrade ansi-regex to version 5.0.1 or later

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,10 +50,9 @@
       "dev": true
     },
     "ansi-regex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-      "dev": true
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA=="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -1721,6 +1720,14 @@
       "dev": true,
       "requires": {
         "ansi-regex": "^4.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        }
       }
     },
     "strip-bom": {

--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
     "boxen": "^2.1.0",
     "chalk": "^2.4.2",
     "standard": "^12.0.1"
+  },
+  "dependencies": {
+    "ansi-regex": ">=5.0.1"
   }
 }


### PR DESCRIPTION
ansi-regex vulnerable versions >2,1,1, <5.0.1
ansi-regex is vulnerable to inefficent regular expression complexity